### PR TITLE
Keep target folder so nada build does not return error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/__pycache__
 nillion-venv/
 permissions/.nillion-config.json
-examples_and_tutorials/nada_programs/target
+examples_and_tutorials/nada_programs/target/*.bin
 quickstart_complete/nada_programs/target
 .env
 .DS_Store


### PR DESCRIPTION
`nada build` requires the `target` folder to have been created beforehand. If it hasn't the user receives the cryptic error message
```
$ nada build
Building program: millionaires
Error: 
   0: No such file or directory (os error 2)

Location:
   tools/nada/src/build.rs:15

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

Nada should probably create this directory automatically if it does not exist, or at least show a more helpful error message.