### PR TITLE
add retrieve permissions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,42 @@ This repo contains examples to go along with the Nillion Python Client docs: htt
 - millionaires_problem_example - An example of Multi Party Compute with the Millionaires Problem Example
 - nada_programs - Single and multi party Nada programs and tests
 - voting_tutorial - An example of Multi Party Compute with voting examples
+
+## Using this repo
+
+### Install dependencies
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Compile programs
+
+From the repo root:
+
+```
+cd examples_and_tutorials/nada_programs
+nada build
+```
+
+### Run the nillion-devnet
+
+```
+nillion-devnet
+```
+
+This writes an Nillion config environment file to your local machine that is used in examples: `load_dotenv(f"{home}/.config/nillion/nillion-devnet.env")`
+
+Keep the devnet running in your terminal.
+
+### Run examples
+
+Open another terminal and navigate to `examples_and_tutorials`, which holds all examples. From the repo root:
+
+```
+cd examples_and_tutorials
+```
+
+Run any examples.

--- a/examples_and_tutorials/core_concept_permissions/04_revoke_read_permissions.py
+++ b/examples_and_tutorials/core_concept_permissions/04_revoke_read_permissions.py
@@ -52,6 +52,22 @@ async def main(args=None):
         prefix="nillion",
     )
 
+
+    # Retrieve current permissions for secret
+    receipt_retrieve_permissions = await get_quote_and_pay(
+        writer,
+        nillion.Operation.retrieve_permissions(),
+        payments_wallet,
+        payments_client,
+        cluster_id,
+    )
+
+    current_permissions = await writer.retrieve_permissions(cluster_id, args.store_id, receipt_retrieve_permissions)
+
+    reader_permissions_before = current_permissions.is_retrieve_allowed(args.revoked_user_id)
+    if reader_permissions_before == False:
+        raise Exception("Reader should still have permissions to retrieve")
+
     # Create new permissions object to rewrite permissions (reader no longer has retrieve permission)
     new_permissions = nillion.Permissions.default_for_user(writer.user_id)
     result = (
@@ -80,6 +96,22 @@ async def main(args=None):
     await writer.update_permissions(
         cluster_id, args.store_id, new_permissions, receipt_update_permissions
     )
+
+
+    # Retrieve current permissions for secret
+    receipt_retrieve_permissions = await get_quote_and_pay(
+        writer,
+        nillion.Operation.retrieve_permissions(),
+        payments_wallet,
+        payments_client,
+        cluster_id,
+    )
+
+    current_permissions = await writer.retrieve_permissions(cluster_id, args.store_id, receipt_retrieve_permissions)
+
+    reader_permissions_after = current_permissions.is_retrieve_allowed(args.revoked_user_id)
+    if reader_permissions_after == True:
+        raise Exception("Reader should no longer have permissions to retrieve the secret")
 
     print(
         "\n\nRun the following command to test that permissions have been properly revoked"


### PR DESCRIPTION
# Added retrieve_permissions examples to core_concept_permissions examples

Get quote and pay for a `retrieve_permissions` operation

```
# Retrieve current permissions for secret
receipt_retrieve_permissions = await get_quote_and_pay(
    writer,
    nillion.Operation.retrieve_permissions(),
    payments_wallet,
    payments_client,
    cluster_id,
)
```

Retrieve permissions for secret and verify that the reader has permissions to the secret (permissions == True)
```
current_permissions = await writer.retrieve_permissions(cluster_id, args.store_id, receipt_retrieve_permissions)

reader_permissions_before = current_permissions.is_retrieve_allowed(args.revoked_user_id)
if reader_permissions_before == False:
    raise Exception("Reader should still have permissions to retrieve")
```